### PR TITLE
[UPD] Sinkronisasi berkas config dengan standar ssi-mixin

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,3 @@
-
 name: pre-commit
 
 on:
@@ -10,10 +9,6 @@ on:
       - "14.0"
       - "14.0-ocabot-*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
@@ -21,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,6 @@ on:
       - "14.0"
       - "14.0-ocabot-*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
@@ -64,10 +60,23 @@ jobs:
         env:
           PIP_INDEX_URL: https://pypi.org/simple
           PIP_EXTRA_INDEX_URL: https://${{ secrets.SSI_PYPI_USER }}:${{ secrets.SSI_PYPI_PASSWORD }}@osmium.simetri-sinergi.biz.id/simple/
+      - name: Pre-install chart of accounts
+        # Memasang l10n_generic_coa ke DB test SEBELUM `oca_init_test_database`.
+        # Saat modul ini berstatus `to install`, pemeriksaan `to_install_l10n`
+        # (account/__init__.py) bernilai benar sehingga `_auto_install_l10n`
+        # berhenti tanpa memasang l10n_us; chart of accounts juga sudah termuat
+        # sebelum demo modul SSI lahir, sehingga `chart_template._load()` tidak
+        # pernah menghapus account.journal/account.account yang dirujuk demo.
+        # Demo TIDAK dimatikan: tour dan skenario uji bergantung padanya.
+        run: |
+          oca_wait_for_postgres
+          odoo -d "$PGDATABASE" -i l10n_generic_coa --http-interface=127.0.0.1 --stop-after-init
       - name: Check licenses
         run: manifestoo -d . check-licenses
+        continue-on-error: true
       - name: Check development status
         run: manifestoo -d . check-dev-status --default-dev-status=Beta
+        continue-on-error: true
       - name: Initialize test db
         run: oca_init_test_database
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md)$'
         language: fail
   - repo: https://github.com/oca/maintainer-tools
-    rev: 31bdbd8e4cb94be6534f0e82b1cafb84a455f671
+    rev: f9b919b9868143135a9c9cb03021089cabba8223
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons

--- a/.pylintrc
+++ b/.pylintrc
@@ -4,16 +4,13 @@
 load-plugins=pylint_odoo
 score=n
 
-[IMPORTS]
-deprecated-modules=pdb,pudb,ipdb,bs4
-
-[ODOOLINT]
-readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=PT. Simetri Sinergi Indonesia
-manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-valid_odoo_versions=14.0
+[odoolint]
+readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+manifest-required-authors=PT. Simetri Sinergi Indonesia
+manifest-required-keys=license
+manifest-deprecated-keys=description,active
+license-allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+valid-odoo-versions=14.0
 
 [MESSAGES CONTROL]
 disable=all
@@ -26,25 +23,9 @@ disable=all
 # config as a blocking check.
 
 enable=anomalous-backslash-in-string,
-    api-one-deprecated,
-    api-one-multi-together,
-    class-camelcase,
-    dangerous-view-replace-wo-priority,
-    duplicate-id-csv,
-    duplicate-xml-fields,
-    duplicate-xml-record-id,
-    eval-referenced,
-    incoherent-interpreter-exec-perm,
-    openerp-exception-warning,
-    redundant-modulename-xml,
-    relative-import,
-    rst-syntax-error,
-    wrong-tabs-instead-of-spaces,
-    xml-syntax-error,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
-    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,
@@ -80,7 +61,6 @@ enable=anomalous-backslash-in-string,
     odoo-addons-relative-import,
     redefined-builtin,
     manifest-external-assets
-
 
 [REPORTS]
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -3,9 +3,6 @@
 load-plugins=pylint_odoo
 score=n
 
-[IMPORTS]
-deprecated-modules=pdb,pudb,ipdb,bs4
-
 [ODOOLINT]
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest_required_authors=PT. Simetri Sinergi Indonesia
@@ -18,25 +15,9 @@ valid_odoo_versions=14.0
 disable=all
 
 enable=anomalous-backslash-in-string,
-    api-one-deprecated,
-    api-one-multi-together,
-    class-camelcase,
-    dangerous-view-replace-wo-priority,
-    duplicate-id-csv,
-    duplicate-xml-fields,
-    duplicate-xml-record-id,
-    eval-referenced,
-    incoherent-interpreter-exec-perm,
-    openerp-exception-warning,
-    redundant-modulename-xml,
-    relative-import,
-    rst-syntax-error,
-    wrong-tabs-instead-of-spaces,
-    xml-syntax-error,
     assignment-from-none,
     attribute-deprecated,
     dangerous-default-value,
-    deprecated-module,
     development-status-allowed,
     duplicate-key,
     eval-used,


### PR DESCRIPTION
## Ringkasan

Menyinkronkan berkas config repo ini ke standar SSI terkini lewat `sync-config.sh 14.0`.

Perubahan utama yang relevan untuk CI: langkah **`Pre-install chart of accounts`**
ditambahkan ke `.github/workflows/test.yml`, dijalankan setelah `oca_install_addons`
dan **sebelum** `oca_init_test_database`:

```yaml
- name: Pre-install chart of accounts
  run: |
    oca_wait_for_postgres
    odoo -d "$PGDATABASE" -i l10n_generic_coa --http-interface=127.0.0.1 --stop-after-init
```

**Sebabnya**: data demo `ssi_school_admission` memegang `account.journal` /
`account.account` lewat foreign key `restrict`. Bila `l10n_generic_coa` belum
terpasang saat `chart_template._load()` berjalan (dipicu instalasi
`l10n_generic_coa` sendiri di tengah `oca_init_test_database`), proses itu mencoba
menghapus seluruh journal bawaan lebih dulu — bentrok dengan FK `restrict` yang
sudah dipegang demo `ssi_school_admission`, menghasilkan `IntegrityError` →
`ParseError`, dan **registry gagal dimuat sama sekali** (nol test dijalankan).
Memasang `l10n_generic_coa` lebih dulu, sebelum demo modul SSI lahir, membuat
`chart_template._load()` tidak pernah perlu menghapus journal yang sudah dirujuk
demo.

Kasus nyata: PR #15 (issue #6), run CI `32479254451`.

Ini **membuka blokir** issue #6 / PR #15 — bukan menyelesaikannya. PR itu masih
perlu lolos CI setelah config ini merge.

## Berkas yang berubah

- `.github/workflows/pre-commit.yml` — hapus blok `concurrency` duplikat, naikkan
  `python-version` dari `3.8` ke `3.11` (mengikuti standar terkini).
- `.github/workflows/test.yml` — tambah langkah `Pre-install chart of accounts`
  (lihat di atas); hapus blok `concurrency` duplikat; tambah `continue-on-error: true`
  pada `Check licenses` dan `Check development status`.
- `.pre-commit-config.yaml` — naikkan pin `oca/maintainer-tools` ke revisi terbaru.
- `.pylintrc` / `.pylintrc-mandatory` — selaraskan ke skema `pylint_odoo` terkini
  (rename section `[ODOOLINT]` → `[odoolint]`, penghapusan beberapa key/check yang
  sudah usang di versi plugin terbaru). Perubahan ini **mengurangi** jumlah check
  yang di-*enable* (lebih permisif), bukan menambah — risiko modul existing gagal
  pre-commit karena ini rendah.

## Test plan

- [ ] CI repo ini (`pre-commit`, `test with Odoo`) hijau untuk PR ini sendiri.
- [ ] Setelah merge, rebase PR #15 (issue #6) di atas `14.0` dan verifikasi step
      `Initialize test db` tidak lagi gagal dengan `IntegrityError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)