### PR TITLE
[14.0] Lindungi field State baris Schedule dari suntingan langsung

### DIFF
--- a/ssi_school_fee_waiver/views/school_fee_waiver.xml
+++ b/ssi_school_fee_waiver/views/school_fee_waiver.xml
@@ -160,7 +160,7 @@
                             <field name="base_amount" />
                             <field name="amount_planned" />
                             <field name="amount_realized" />
-                            <field name="state" />
+                            <field name="state" readonly="1" />
                             <field name="note" />
                             <field name="currency_id" invisible="1" />
                             <button
@@ -184,7 +184,7 @@
                                 <field name="base_amount" />
                                 <field name="amount_planned" />
                                 <field name="amount_realized" />
-                                <field name="state" />
+                                <field name="state" readonly="1" />
                                 <field name="currency_id" invisible="1" />
                             </group>
                             <field name="note" />


### PR DESCRIPTION
## Ringkasan

Menambahkan atribut `readonly="1"` pada kedua node `<field name="state" />` milik
`schedule_ids` di `views/school_fee_waiver.xml` — tree `editable="bottom"` (baris 163)
dan form bersarangnya (baris 187) — sehingga field `state` pada baris Schedule tidak
lagi bisa disunting langsung dari grid/form oleh pengguna.

## Konteks

Discovery Odoo YPII (24-25 Agustus 2026) menemukan bahwa field `state` yang bisa
disunting langsung dari grid Schedule menembus penghadangan
`_10_check_realized_schedule` (`@ssi_decorator.pre_cancel_action()`) yang menolak
pembatalan Waiver bila ada baris Schedule berstatus `realized` — pengguna cukup
mengubah baris itu kembali ke `draft`/`scheduled` dari grid sebelum membatalkan,
tanpa melalui `action_skip`/`action_cancel_schedule` yang punya guard
`_check_skip_cancel_allowed`.

## Keputusan Desain (dari issue)

- Field `state` di model `school_fee_waiver_schedule` **tetap** `fields.Selection`
  biasa, **tidak** diberi `readonly=True` di level Python — supaya
  `_skip`/`_cancel_schedule`/`_generate_schedule` (menulis `state` lewat `write()`
  internal via `sudo()`) dan modul deduction tetap bisa menuliskannya.
- `readonly="1"` statis, tanpa `attrs=`/kondisi.
- Tombol `action_skip`/`action_cancel_schedule` tidak diubah — keduanya memanggil
  `sudo()` lalu menulis `state` lewat ORM Python, tidak terpengaruh atribut
  `readonly` view (hanya membatasi widget input web client).

## Ruang Lingkup

Permukaan perubahan murni `views/` — 2 baris diubah, tidak ada perubahan field/method
Python. Tidak ada test/tour/IK yang jadi salah (`**Artefak terdampak:** nihil` di
issue) — tour yang ada hanya memverifikasi baris Schedule muncul, tidak pernah
menyunting sel `state`.

Closes #22