### PR TITLE
[UPD] ssi_school_fee_waiver - Hapus duplikasi field generate_schedule_ok

### DIFF
--- a/ssi_school_fee_waiver/views/school_fee_waiver.xml
+++ b/ssi_school_fee_waiver/views/school_fee_waiver.xml
@@ -69,7 +69,6 @@
     <field name="arch" type="xml">
         <data>
             <xpath expr="//header" position="inside">
-                <field name="generate_schedule_ok" invisible="1" />
                 <button
                         name="action_generate_schedule"
                         type="object"


### PR DESCRIPTION
## Ringkasan

Menghapus deklarasi field `generate_schedule_ok` yang berlebih (duplikat) di view
`school_fee_waiver_view_form` (`views/school_fee_waiver.xml`). Field ini sebelumnya
diletakkan dua kali:

- tersembunyi (`invisible="1"`) di dalam `//header`, sebagai penyetir `attrs` tombol
  **Generate Schedule**;
- terlihat di `//group[@name='policy_2']`.

Aturan `07-views.md` Aturan 8 menuntut satu field hanya diletakkan satu kali per view.
Deklarasi di header dihapus; field tetap hadir (visible) di group `policy_2` sehingga
status policy tetap terlihat pengguna — group policy adalah rumah kanonik field `*_ok`
di form transaksional SSI. Tombol `action_generate_schedule` tidak diubah dan tetap
berfungsi karena Odoo hanya menuntut field hadir di arch view yang sama; kehadirannya di
dalam `<page>` notebook grup policy sudah memenuhi syarat itu.

Tidak ada perubahan model, field, security, maupun manifest.

## Sumber

Temuan T-01 dari sapuan kepatuhan `audit-sweep.sh 14.0 --repo ssi-school-fee-waiver --force`
(6 Sep 2026, validator `module` v3.57.0).

## Verifikasi

- `verify-module.sh ssi_school_fee_waiver 14.0` → `LOLOS: 0 ERROR, 2 peringatan, 0 tertunda`
  (dua peringatan pra-ada, di luar lingkup: keseimbangan `header_left`/`header_right` dan
  `open_ok` tanpa `policy.template_detail`).
- `pre-commit-gate.sh` → `GATE OK`.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvRMT3fz83xurLyWf5BT1o