### PR TITLE
[UPD] ssi_school_fee_waiver_deduction: rapikan tata letak view sesuai 07-views

### DIFF
--- a/ssi_school_fee_waiver_deduction/docs/school_fee_waiver_deduction/01-create.md
+++ b/ssi_school_fee_waiver_deduction/docs/school_fee_waiver_deduction/01-create.md
@@ -24,11 +24,12 @@
    - **Waiver** _(required)_: Select the fee waiver document this deduction realizes.
      Selecting it fills Student and Partner, and defaults **Journal** from the waiver's
      own Fee Waiver Type.
+   - **Date**: Defaults to today's date.
+4. On the **Accounting** tab, fill in:
    - **Journal** _(required)_: Defaults from the Waiver's Type; may be overridden.
    - **Receivable Account** _(required)_: Select the receivable account credited for the
      total deduction amount.
-   - **Date**: Defaults to today's date.
-4. On the **Lines** tab, add **at least one** line:
+5. On the **Lines** tab, add **at least one** line:
    - **Schedule** _(required)_: Select a Scheduled line of the selected Waiver.
      Selecting it defaults **Account** from the Schedule's own Waiver Type.
    - **Account** _(required)_: Defaults from the Schedule's own Waiver Type; may be
@@ -36,12 +37,12 @@
    - **Analytic Account**: Optional.
    - **Amount** _(required)_: The portion of the Schedule line's own Amount Planned
      being deducted now. May not exceed the Schedule line's remaining planned amount.
-5. On the **Allocations** tab, add **at least one** line:
+6. On the **Allocations** tab, add **at least one** line:
    - **Customer Invoice** _(required)_: Select an open invoice of the Waiver's own
      Partner with a positive residual.
    - **Amount** _(required)_: The portion of this document's Amount Total applied to the
      selected invoice. May not exceed the invoice's own residual.
-6. Click **Save**.
+7. Click **Save**.
 
 ## Post-Condition
 

--- a/ssi_school_fee_waiver_deduction/static/tests/tours/school_fee_waiver_deduction_tour.js
+++ b/ssi_school_fee_waiver_deduction/static/tests/tours/school_fee_waiver_deduction_tour.js
@@ -101,6 +101,11 @@ odoo.define(
                     in_modal: false,
                 },
                 {
+                    content: "Open the Accounting tab",
+                    trigger: ".o_notebook .nav-link:contains(Accounting)",
+                    extra_trigger: ".o_form_view.o_form_editable",
+                },
+                {
                     content: "Journal was defaulted from the Waiver's own Type",
                     trigger: ".o_field_many2one[name='journal_id'] input",
                     run: function () {

--- a/ssi_school_fee_waiver_deduction/views/school_fee_waiver_deduction.xml
+++ b/ssi_school_fee_waiver_deduction/views/school_fee_waiver_deduction.xml
@@ -62,13 +62,13 @@
                 <field name="waiver_id" />
                 <field name="student_id" />
                 <field name="partner_id" />
-                <field name="journal_id" />
-                <field name="receivable_account_id" />
             </xpath>
             <xpath expr="//group[@name='header_right']" position="inside">
                 <field name="date" />
                 <field name="currency_id" invisible="1" />
                 <field name="company_currency_id" invisible="1" />
+            </xpath>
+            <xpath expr="//group[@name='footer_left']" position="inside">
                 <field
                         name="amount_total"
                         widget="monetary"
@@ -84,11 +84,17 @@
                         widget="monetary"
                         options="{'currency_field': 'currency_id'}"
                     />
-                <field name="reconciled" />
-                <field name="move_id" />
-                <field name="receivable_move_line_id" />
             </xpath>
             <xpath expr="//page[1]" position="before">
+                <page name="accounting" string="Accounting">
+                    <group name="accounting_1" colspan="4" col="2">
+                        <field name="journal_id" />
+                        <field name="receivable_account_id" />
+                        <field name="move_id" readonly="1" />
+                        <field name="receivable_move_line_id" readonly="1" />
+                        <field name="reconciled" readonly="1" />
+                    </group>
+                </page>
                 <page name="line" string="Lines">
                     <field name="line_ids" colspan="4" nolabel="1">
                         <tree editable="bottom">

--- a/ssi_school_fee_waiver_deduction/views/school_fee_waiver_schedule.xml
+++ b/ssi_school_fee_waiver_deduction/views/school_fee_waiver_schedule.xml
@@ -11,13 +11,13 @@
     <field name="arch" type="xml">
         <data>
             <xpath
-                    expr="//page[@name='schedule']//tree/field[@name='amount_realized']"
+                    expr="//field[@name='schedule_ids']/tree/field[@name='amount_realized']"
                     position="after"
                 >
                 <field name="deduction_id" />
             </xpath>
             <xpath
-                    expr="//page[@name='schedule']//form//field[@name='amount_realized']"
+                    expr="//field[@name='schedule_ids']/form//field[@name='amount_realized']"
                     position="after"
                 >
                 <field name="deduction_id" />


### PR DESCRIPTION
## Ringkasan

Merapikan tata letak view `ssi_school_fee_waiver_deduction` sesuai standar `07-views.md`
untuk menghilangkan 4 temuan ERROR dari sapuan audit `audit-sweep.sh 14.0 --force`
(6 Sep 2026, validator `module` v3.57.0):

- **T-02/T-03**: Bentuk page `Accounting` berisi `journal_id`, `receivable_account_id`,
  `move_id`, `receivable_move_line_id`, `reconciled` dalam urutan rantai sebab-akibat
  (Aturan 7). `receivable_account_id` ikut dipindah meski tak disebut baris temuan
  validator — ia golongan 1 dan tercantum di bentuk kanonik pasal itu; meninggalkannya di
  header mengulang cacat susulan `ssi-school-scholarship#86`.
- **T-04**: `amount_total`/`amount_allocated`/`amount_unallocated` dipindah ke
  `footer_left`, bukan `header_right`.
- **T-05**: Kedua xpath `deduction_id` di `school_fee_waiver_schedule.xml` dianker ulang
  dari `//page[@name='schedule']//tree|form` ke
  `//field[@name='schedule_ids']/tree|form//`, mengikuti pola
  `ssi_school_fee_waiver_admission/views/school_fee_waiver.xml:24-35` yang sudah lolos
  validator. Kedua penempatan `deduction_id` tetap dipertahankan (tree + inline form
  baris), tidak ada field yang dihapus.

IK `01-create.md` dan tour pasangannya (`school_fee_waiver_deduction_tour.js`) diselaraskan
dengan lokasi baru Journal & Receivable Account di tab **Accounting**.

Tidak ada perubahan model, field Python, security, atau manifest. `version` tidak disentuh.

## Verifikasi

```
#VALIDATOR name=module target=ssi_school_fee_waiver_deduction series=14.0 error=0 warn=1 defer=0 excepted=0 warisan=0 status=OK
#VALIDATOR name=ik target=ssi_school_fee_waiver_deduction series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=tour target=ssi_school_fee_waiver_deduction series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Peringatan `warn=1` (validator `module`) adalah temuan `open_ok` tanpa `policy.template_detail`
di modul ini — eksplisit di luar lingkup item ini (`## Tidak termasuk`).

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvRMT3fz83xurLyWf5BT1o