### PR TITLE
[UPD] ssi_school_fee_waiver - rapikan tombol Start dan keseimbangan header

### DIFF
--- a/ssi_school_fee_waiver/docs/school_fee_waiver/08-auto-open.md
+++ b/ssi_school_fee_waiver/docs/school_fee_waiver/08-auto-open.md
@@ -7,11 +7,11 @@
 > **State:** `confirm` → `open`\
 > **Requires:** `05-approve`
 
-There is no **Start** button on this model: the mixin-inserted button
-(`attrs="{'invisible':[('open_ok','!=',True)]}"`) never becomes visible, since this
-model's policy template has no active row for `open_ok`. The transition to **On
-Progress** is performed automatically by `action_approve_approval` itself, right after
-the last pending approval level is fulfilled.
+There is no **Start** button on this model: `school_fee_waiver` sets
+`_automatically_insert_open_button = False`, so the mixin never inserts the button in
+the first place -- there is no active policy row for `open_ok` to grant it against. The
+transition to **On Progress** is performed automatically by `action_approve_approval`
+itself, right after the last pending approval level is fulfilled.
 
 ## Pre-Condition
 

--- a/ssi_school_fee_waiver/models/school_fee_waiver.py
+++ b/ssi_school_fee_waiver/models/school_fee_waiver.py
@@ -55,6 +55,7 @@ class SchoolFeeWaiver(models.Model):
 
     # Attributes related to add element on view automatically
     _automatically_insert_view_element = True
+    _automatically_insert_open_button = False
 
     _statusbar_visible_label = "draft,confirm,open,done"
     _policy_field_order = [

--- a/ssi_school_fee_waiver/views/school_fee_waiver.xml
+++ b/ssi_school_fee_waiver/views/school_fee_waiver.xml
@@ -86,6 +86,15 @@
                         domain="[('student_id', '=', student_id)]"
                         attrs="{'required': [('source_type', '=', 'enrollment')], 'invisible': [('source_type', '!=', 'enrollment')]}"
                     />
+            </xpath>
+            <xpath expr="//group[@name='header_right']" position="inside">
+                <field name="date" />
+                <field name="company_currency_id" invisible="1" />
+                <field
+                        name="amount_waived"
+                        widget="monetary"
+                        options="{'currency_field': 'company_currency_id'}"
+                    />
                 <field name="school_id" />
                 <field name="grade_id" />
                 <field name="academic_year_id" />
@@ -102,15 +111,6 @@
                 <field
                         name="date_end"
                         attrs="{'invisible': [('coverage', '!=', 'multi_term')]}"
-                    />
-            </xpath>
-            <xpath expr="//group[@name='header_right']" position="inside">
-                <field name="date" />
-                <field name="company_currency_id" invisible="1" />
-                <field
-                        name="amount_waived"
-                        widget="monetary"
-                        options="{'currency_field': 'company_currency_id'}"
                     />
             </xpath>
             <xpath expr="//page[1]" position="before">


### PR DESCRIPTION
## Ringkasan

Sapuan `audit-sweep.sh 14.0 --repo ssi-school-fee-waiver --force` (6 Sep 2026, validator
`module` v3.57.0) meninggalkan dua peringatan `!` pada `ssi_school_fee_waiver`:

- **T-07** — `open_ok` tanpa `policy.template_detail`: transisi `confirm` -> `open` tak
  pernah memeriksa policy (`bypass_policy_check=True` dari `mixin_multiple_approval`),
  tapi `mixin.transaction_open` tetap menyisipkan tombol Start karena
  `_automatically_insert_open_button` default `True`.
- **T-06** — header timpang (kiri=16, kanan=3), selisih 13 melampaui ambang gerbang
  `_HDR_TIMPANG = 5`.

## Perubahan

- Setel `_automatically_insert_open_button = False` pada `school_fee_waiver` (bersebelahan
  dengan `_after_approved_method = "action_open"`), sehingga tombol Start tidak lagi
  disisipkan. Tidak menambah grant `open_ok`, tidak menulis `.validator-exceptions`.
- Pindahkan tujuh field (`school_id`, `grade_id`, `academic_year_id`, `coverage`,
  `payment_term_id`, `date_start`, `date_end`) dari `header_left` ke `header_right` pada
  `school_fee_waiver_view_form`. Komposisi akhir: kiri 9, kanan 10 (selisih 1). Kelompok
  `coverage`/`payment_term_id`/`date_start`/`date_end` (ber-`attrs` pada `coverage`) pindah
  utuh bersama.
- Selaraskan paragraf pembuka `docs/school_fee_waiver/08-auto-open.md` -- tombol Start
  tidak pernah disisipkan, bukan tersisip tapi tak terlihat. Pre-Condition, Flow, dan
  Post-Condition tidak berubah.

## Yang tidak berubah

- Tidak ada field ditambah/dihapus/diganti nama, dan tidak ada `domain`/`attrs`/widget yang
  berubah -- diff `views/` murni memindahkan baris.
- Tidak ada perubahan security/manifest; `version` tidak disentuh.
- Tidak ada skenario `odoo-yaml-test` baru; seluruh test yang sudah ada (termasuk yang
  menempuh `confirm` -> `open` lewat approval) tetap hijau apa adanya.
- Tour `static/tests/tours/school_fee_waiver_tour.js` tidak berubah -- selector `[name='...']`
  yang dipakainya tidak menjangkar pada group induk.

## Verifikasi

```
#VALIDATOR name=module target=.../ssi_school_fee_waiver series=14.0 error=0 warn=0 defer=0 excepted=0 warisan=0 status=OK
#VALIDATOR name=ik target=.../ssi_school_fee_waiver series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`pre-commit-gate.sh`: `GATE OK` (Tahap 0 + 6 validator, 0 pelanggaran baru).

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvRMT3fz83xurLyWf5BT1o