### PR TITLE
[UPD] ssi_school_fee_waiver_deduction: setel _automatically_insert_open_button False

### DIFF
--- a/ssi_school_fee_waiver_deduction/docs/school_fee_waiver_deduction/08-auto-open.md
+++ b/ssi_school_fee_waiver_deduction/docs/school_fee_waiver_deduction/08-auto-open.md
@@ -7,11 +7,11 @@
 > **State:** `confirm` → `open`\
 > **Requires:** `05-approve`
 
-There is no **Start** button on this model: the mixin-inserted button
-(`attrs="{'invisible':[('open_ok','!=',True)]}"`) never becomes visible, since this
-model's policy template has no active row for `open_ok`. The transition to **On
-Progress** is performed automatically by `action_approve_approval` itself, right after
-the last pending approval level is fulfilled.
+There is no **Start** button on this model: this model sets
+`_automatically_insert_open_button = False`, so the mixin never inserts the button in
+the first place, and its policy template has no active row for `open_ok`. The transition
+to **On Progress** is performed automatically by `action_approve_approval` itself, right
+after the last pending approval level is fulfilled.
 
 ## Pre-Condition
 

--- a/ssi_school_fee_waiver_deduction/models/school_fee_waiver_deduction.py
+++ b/ssi_school_fee_waiver_deduction/models/school_fee_waiver_deduction.py
@@ -50,6 +50,7 @@ class SchoolFeeWaiverDeduction(models.Model):
     _approval_to_state = "open"
     _approval_state = "confirm"
     _after_approved_method = "action_open"
+    _automatically_insert_open_button = False
 
     # Attributes related to add element on view automatically
     _automatically_insert_view_element = True


### PR DESCRIPTION
## Ringkasan

Sapuan `audit-sweep.sh 14.0 --repo ssi-school-fee-waiver --force` (6 Sep 2026) menerbitkan
peringatan `!` pada `ssi_school_fee_waiver_deduction`: policy field `open_ok` tanpa record
`policy.template_detail`. Peringatan itu **sah** — transisi `confirm` -> `open` memang
otomatis (`_after_approved_method = "action_open"`, dipanggil `action_approve_approval`
dengan `bypass_policy_check=True`), jadi `open_ok` memang tidak pernah diperiksa. Tapi
`mixin.transaction_open` tetap menyisipkan tombol Start ke view karena
`_automatically_insert_open_button` default-nya `True` — tombol yang tersisip lalu tidak
pernah terlihat.

## Perubahan

- Setel `_automatically_insert_open_button = False` pada `school_fee_waiver_deduction`,
  bersebelahan dengan `_after_approved_method = "action_open"` yang sudah ada.
- Selaraskan paragraf pembuka `docs/school_fee_waiver_deduction/08-auto-open.md` agar
  menyebut tombol tidak pernah disisipkan, bukan tersisip lalu tak pernah terlihat.

## Verifikasi

- `verify-module.sh` sebelum: `warn=1` (temuan `open_ok`). Sesudah: `warn=0`, mencetak
  `· 1 policy field tidak diperiksa — tombolnya sengaja tak disisipkan`.
- `validate-ik.sh`: `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`, exit 0.
- Tidak ada record `policy.template_detail` untuk `open_ok` yang ditambahkan, dan tidak
  ada baris `.validator-exceptions` yang ditulis — sesuai Keputusan Desain issue.
- Tidak ada perubahan view/security/manifest; `version` tidak disentuh.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvRMT3fz83xurLyWf5BT1o