### PR TITLE
[UPD] ssi_school_fee_waiver: cegah duplikasi jadwal saat regenerasi waiver sumber Admission

### DIFF
--- a/ssi_school_fee_waiver/models/school_fee_waiver.py
+++ b/ssi_school_fee_waiver/models/school_fee_waiver.py
@@ -550,7 +550,14 @@ Solution: The realized period can no longer be withdrawn by cancelling this waiv
         Schedule line in ``realized``, ``skipped``, or ``cancelled``
         is left untouched -- it is never a match target for deletion
         or a duplicate target for creation, so a period already
-        settled or withdrawn survives regeneration unchanged.
+        settled or withdrawn survives regeneration unchanged. The
+        pairing is matched through each existing Schedule line's own
+        ``_get_source_term()`` -- its effective source term -- rather
+        than the raw ``payment_term_id`` field, so an extension module
+        that keys its Schedule lines off a different source field
+        (e.g. ``admission_payment_term_id``) is still matched
+        correctly and does not get its already-realized/skipped/
+        cancelled lines duplicated.
 
         :param bypass_policy_check: skip the ``generate_schedule_ok``
             policy check, used when called from
@@ -565,20 +572,17 @@ Solution: The realized period can no longer be withdrawn by cancelling this waiv
             lambda schedule: schedule.state in ("draft", "scheduled")
         )
         stale.unlink()
-        schedule_obj = self.env["school_fee_waiver_schedule"]
         terms = self._get_schedule_payment_terms()
         for line in self.line_ids:
+            scheduled_term_ids = line.schedule_ids.mapped(
+                lambda schedule: schedule._get_source_term().id
+            )
             for term in terms:
-                existing = schedule_obj.search(
-                    [
-                        ("line_id", "=", line.id),
-                        ("payment_term_id", "=", term.id),
-                    ],
-                    limit=1,
-                )
-                if existing:
+                if term.id in scheduled_term_ids:
                     continue
-                schedule_obj.create(self._prepare_schedule_data(line, term))
+                self.env["school_fee_waiver_schedule"].create(
+                    self._prepare_schedule_data(line, term)
+                )
 
     def _check_generate_schedule_policy(self):
         """Reject schedule generation when the policy check fails.

--- a/ssi_school_fee_waiver/models/school_fee_waiver.py
+++ b/ssi_school_fee_waiver/models/school_fee_waiver.py
@@ -574,9 +574,9 @@ Solution: The realized period can no longer be withdrawn by cancelling this waiv
         stale.unlink()
         terms = self._get_schedule_payment_terms()
         for line in self.line_ids:
-            scheduled_term_ids = line.schedule_ids.mapped(
-                lambda schedule: schedule._get_source_term().id
-            )
+            scheduled_term_ids = [
+                schedule._get_source_term().id for schedule in line.schedule_ids
+            ]
             for term in terms:
                 if term.id in scheduled_term_ids:
                     continue

--- a/ssi_school_fee_waiver/tests/test_data_school_fee_waiver_schedule.yaml
+++ b/ssi_school_fee_waiver/tests/test_data_school_fee_waiver_schedule.yaml
@@ -630,7 +630,9 @@ scenarios:
       - step: "Find the Category B Schedule line"
         action: "search"
         model: "school_fee_waiver_schedule"
-        domain: [["payment_term_id", "=", "REC: fs1_term5.id"]]
+        domain:
+          - ["waiver_id", "=", "REC: fs1_single_full.id"]
+          - ["payment_term_id", "=", "REC: fs1_term5.id"]
         save_as: "fs1_sched_categ"
         limit: 1
 
@@ -688,7 +690,9 @@ scenarios:
       - step: "Find the Fixed Amount Schedule line"
         action: "search"
         model: "school_fee_waiver_schedule"
-        domain: [["payment_term_id", "=", "REC: fs1_term4.id"]]
+        domain:
+          - ["waiver_id", "=", "REC: fs1_fixed.id"]
+          - ["payment_term_id", "=", "REC: fs1_term4.id"]
         save_as: "fs1_sched_fixed"
         limit: 1
 
@@ -747,7 +751,9 @@ scenarios:
       - step: "Find the Max Amount Schedule line"
         action: "search"
         model: "school_fee_waiver_schedule"
-        domain: [["payment_term_id", "=", "REC: fs1_term1.id"]]
+        domain:
+          - ["waiver_id", "=", "REC: fs1_max.id"]
+          - ["payment_term_id", "=", "REC: fs1_term1.id"]
         save_as: "fs1_sched_max"
         limit: 1
 
@@ -872,7 +878,9 @@ scenarios:
       - step: "Find the Realized-test Schedule line"
         action: "search"
         model: "school_fee_waiver_schedule"
-        domain: [["payment_term_id", "=", "REC: fs1_term6.id"]]
+        domain:
+          - ["waiver_id", "=", "REC: fs1_realized_test.id"]
+          - ["payment_term_id", "=", "REC: fs1_term6.id"]
         save_as: "fs1_sched_realize"
         limit: 1
 

--- a/ssi_school_fee_waiver/tests/test_data_school_fee_waiver_schedule.yaml
+++ b/ssi_school_fee_waiver/tests/test_data_school_fee_waiver_schedule.yaml
@@ -449,6 +449,136 @@ scenarios:
             type: "value"
             expected: "skipped"
 
+      # ── Regenerate guard matches by _get_source_term(), not the raw
+      # payment_term_id domain (issue #37): a Realized line must not
+      # be duplicated, and a term that only later becomes eligible
+      # still gets its own Schedule line ─────────────────────────────
+      - step: "Create a second multi-term waiver (Aug-Sep coverage)"
+        action: "create"
+        model: "school_fee_waiver"
+        save_as: "fs1_multi2"
+        values:
+          type_id: "REC: fs1_type.id"
+          reason_id: "REC: fs1_reason.id"
+          student_id: "REC: fs1_student.id"
+          enrollment_id: "REC: fs1_enrollment.id"
+          coverage: "multi_term"
+          date_start: 2026-08-01
+          date_end: 2026-09-30
+          user_id: "REF: base.user_admin"
+          line_ids:
+            - - 0
+              - 0
+              - product_id: "REC: fs1_product_a.id"
+                computation: "percentage"
+                percentage: 50.0
+
+      - step: "Confirm the second multi-term waiver"
+        action: "call"
+        target: "fs1_multi2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve the second multi-term waiver"
+        action: "call"
+        target: "fs1_multi2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Second waiver got Schedule lines for August and September"
+        action: "assert"
+        target: "fs1_multi2"
+        asserts:
+          schedule_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 2
+
+      - step: "Find the second waiver's own Line"
+        action: "search"
+        model: "school_fee_waiver_line"
+        domain: [["waiver_id", "=", "REC: fs1_multi2.id"]]
+        save_as: "fs1_multi2_line"
+        limit: 1
+
+      - step: "Find the second waiver's August Schedule line"
+        action: "search"
+        model: "school_fee_waiver_schedule"
+        domain:
+          - ["line_id", "=", "REC: fs1_multi2_line.id"]
+          - ["payment_term_id", "=", "REC: fs1_term2.id"]
+        save_as: "fs1_multi2_sched_aug"
+        limit: 1
+
+      - step: "Force the second waiver's August line to Realized"
+        action: "write"
+        target: "fs1_multi2_sched_aug"
+        as_user: "base.user_admin"
+        values:
+          state: "realized"
+
+      - step: "Regenerate must not duplicate the Realized August line"
+        action: "call"
+        target: "fs1_multi2"
+        method: "action_generate_schedule"
+        as_user: "base.user_admin"
+
+      - step: "Exactly one Schedule line still covers August"
+        action: "search"
+        model: "school_fee_waiver_schedule"
+        domain:
+          - ["line_id", "=", "REC: fs1_multi2_line.id"]
+          - ["payment_term_id", "=", "REC: fs1_term2.id"]
+        save_as: "fs1_multi2_sched_aug_after"
+        expect_count: 1
+
+      - step: "The surviving August line is still Realized"
+        action: "assert"
+        target: "fs1_multi2_sched_aug_after"
+        asserts:
+          state:
+            type: "value"
+            expected: "realized"
+
+      - step: "Widen the second waiver's coverage to include October"
+        action: "write"
+        target: "fs1_multi2"
+        as_user: "base.user_admin"
+        values:
+          date_end: 2026-10-31
+
+      - step: "Regenerate again after widening the date range"
+        action: "call"
+        target: "fs1_multi2"
+        method: "action_generate_schedule"
+        as_user: "base.user_admin"
+
+      - step: "October, newly eligible, gets its own Schedule line"
+        action: "search"
+        model: "school_fee_waiver_schedule"
+        domain:
+          - ["line_id", "=", "REC: fs1_multi2_line.id"]
+          - ["payment_term_id", "=", "REC: fs1_term4.id"]
+        save_as: "fs1_multi2_sched_oct"
+        expect_count: 1
+
+      - step: "Realized August survived, September and October both present"
+        action: "assert"
+        target: "fs1_multi2"
+        asserts:
+          schedule_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 3
+
       # ── Single Term, Full Coverage, matched by Product Category ────
       - step: "Create the single-term waiver (Full Coverage, by Category)"
         action: "create"

--- a/ssi_school_fee_waiver/tests/test_school_fee_waiver_schedule.py
+++ b/ssi_school_fee_waiver/tests/test_school_fee_waiver_schedule.py
@@ -17,9 +17,11 @@ class TestSchoolFeeWaiverSchedule(YamlTransactionCase):
         Covers Single/Multiple Payment Terms generation, matching by
         Product and by Product Category, all three ``computation``
         values, the Max Amount ceiling, idempotent regeneration
-        (including after Skip/Cancel), Amount Waived recomputation,
-        the duplicate (Line, Payment Term) constraint, the Payment
-        Term ownership constraint, and rejection of Skip/Cancel on a
-        Realized line.
+        (including after Skip/Cancel), the regenerate guard matching
+        pairings by ``_get_source_term()`` -- a Realized line is not
+        duplicated and a newly-eligible term still gets scheduled,
+        Amount Waived recomputation, the duplicate (Line, Payment
+        Term) constraint, the Payment Term ownership constraint, and
+        rejection of Skip/Cancel on a Realized line.
         """
         self.run_yaml_scenario("test_data_school_fee_waiver_schedule.yaml")


### PR DESCRIPTION
## Ringkasan

Guard anti-duplikat di `_generate_schedule` (`school_fee_waiver.py`) mencari baris
`school_fee_waiver_schedule` yang sudah ada lewat domain mentah `payment_term_id = term.id`.
Modul turunan `ssi_school_fee_waiver_admission` membiarkan `payment_term_id` kosong dan
menyimpan terminnya di `admission_payment_term_id`, sehingga guard itu tidak pernah cocok
untuk baris Admission -- setiap regenerasi jadwal selalu membuat baris baru, termasuk untuk
termin yang sudah `realized`.

Perbaikan mengganti sumber pencocokan guard dari `payment_term_id` mentah menjadi
`_get_source_term()` -- termin efektif tiap baris Schedule -- yang sudah menjadi hook
ekstensi resmi di `school_fee_waiver_schedule.py` dan sudah di-override oleh
`ssi_school_fee_waiver_admission`. Modul `ssi_school_fee_waiver_admission` sendiri **tidak
disentuh**.

## Perubahan

- `models/school_fee_waiver.py`: `_generate_schedule` mencocokkan pasangan (Line, Termin)
  lewat `_get_source_term()` tiap baris `line.schedule_ids`, bukan `search()` dengan domain
  `payment_term_id`. Perilaku `unlink` baris `draft`/`scheduled` tidak berubah. Docstring
  method diperbarui.
- `tests/test_data_school_fee_waiver_schedule.yaml` + `tests/test_school_fee_waiver_schedule.py`:
  skenario baru membuktikan baris `realized` tidak digandakan saat regenerasi, dan termin
  yang baru menjadi eligible (setelah rentang tanggal diperlebar) tetap dijadwalkan.

## Verifikasi

- `verify-module.sh ssi_school_fee_waiver 14.0` -- `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `odoo-development-unit-test/assets/verify-tests.sh ssi_school_fee_waiver` -- `TESTS OK`
- `odoo-development-unit-test/assets/validate-unit-test.sh ssi_school_fee_waiver 14.0` -- `LOLOS: 0 ERROR, 0 peringatan, 0 tertunda`
- `odoo-development-repo-ops/assets/pre-commit-gate.sh` -- `GATE OK`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srxhi4LMEGJ1Uybgn8wR3i